### PR TITLE
NT_MAKEFILE: support targeting ARM64 with MSVC

### DIFF
--- a/NT_MAKEFILE
+++ b/NT_MAKEFILE
@@ -1,6 +1,7 @@
 # Makefile for Windows (Win32/64).  Assumes Microsoft compiler.
 # Should be invoked as "nmake -f NT_MAKEFILE [<args>]"; the optional arguments
 # are: "cpu=AMD64" - to target x64, "cpu=i386" - to target x86,
+# "cpu=ARM64" - to target Windows on ARM64,
 # "enable_static=1" - to build it as a static library, "nodebug=1" - to produce
 # the release variant of the library, "disable_threads=1" - to build the
 # library and the tests without threads support.
@@ -16,6 +17,8 @@ CPU = $(PROCESSOR_ARCHITECTURE)
 CPU = i386
 !ELSEIF "$(CPU)" == "X64" || "$(CPU)" == "x64" || "$(CPU)" == "amd64"
 CPU = AMD64
+!ELSEIF "$(CPU)" == "arm64" || "$(CPU)" == "AARCH64" || "$(CPU)" == "aarch64"
+CPU = ARM64
 !ENDIF
 
 !IF !DEFINED(NMAKE_WINVER)
@@ -27,6 +30,8 @@ cflags = $(cflags) -c -DCRTAPI1=_cdecl -DCRTAPI2=_cdecl -GS -D_WINNT -W4
 cflags = $(cflags) -D_X86_=1  -DWIN32 -D_WIN32
 !ELSEIF "$(CPU)" == "AMD64"
 cflags = $(cflags) -D_AMD64_=1 -DWIN64 -D_WIN64  -DWIN32 -D_WIN32
+!ELSEIF "$(CPU)" == "ARM64"
+cflags = $(cflags) -D_ARM64_=1 -DWIN64 -D_WIN64  -DWIN32 -D_WIN32
 !ENDIF
 cflags = $(cflags) -D_WIN32_WINNT=$(NMAKE_WINVER) -DWINVER=$(NMAKE_WINVER)
 
@@ -46,6 +51,8 @@ ldebug = /DEBUG /DEBUGTYPE:cv
 CVTRES_CPU=X86
 !ELSEIF "$(CPU)" == "AMD64"
 CVTRES_CPU=X64
+!ELSEIF "$(CPU)" == "ARM64"
+CVTRES_CPU=ARM64
 !ENDIF
 
 !IFNDEF NODEBUG


### PR DESCRIPTION
Extend NT_MAKEFILE with a third CPU branch so that building gc.lib with
MSVC can target Windows on ARM64, alongside the existing i386 and AMD64
branches. Accept CPU values of ARM64, arm64, AARCH64, aarch64; define
_ARM64_=1 and the Win64/Win32 convention macros; set CVTRES_CPU=ARM64.

This is needed for Mercury's MSVC port to support Windows ARM64. It is
also a generally useful improvement to Boehm's Windows build.